### PR TITLE
Fix the build issues caused by pattern rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,19 +69,19 @@ LD_FLAGS = $(MC_FLAGS) -g -gdwarf-2 -mthumb -nostartfiles -Xlinker --gc-sections
 all: $(OBJECTS) $(PROJECT_NAME).elf  $(PROJECT_NAME).hex $(PROJECT_NAME).bin
 	$(TOOLCHAIN)size $(PROJECT_NAME).elf
 
-%o: %c
+%.o: %.c
 	$(CC) -c $(CP_FLAGS) -I . $(INC_DIR) $< -o $@
 
-%o: %s
+%.o: %.s
 	$(AS) -c $(AS_FLAGS) $< -o $@
 
-%elf: $(OBJECTS)
+%.elf: $(OBJECTS)
 	$(CC) $(OBJECTS) $(LD_FLAGS) -o $@
 
-%hex: %elf
+%.hex: %.elf
 	$(HEX) $< $@
 
-%bin: %elf
+%.bin: %.elf
 	$(BIN)  $< $@
 
 flash: $(PROJECT_NAME).bin


### PR DESCRIPTION
'.' should be added about the pattern rules.
I tried both on debian9 and Cygwin, the build failed.

Based on examples in 'https://www.gnu.org/software/make/manual/make.html',
the dots should be added.